### PR TITLE
Remove `next` from nvim-metals

### DIFF
--- a/dot_config/nvim/init.vim
+++ b/dot_config/nvim/init.vim
@@ -14,7 +14,7 @@ Plug 'hrsh7th/nvim-compe'
 Plug 'simrat39/symbols-outline.nvim'
 Plug 'glepnir/lspsaga.nvim'
 Plug 'mfussenegger/nvim-jdtls'
-Plug 'scalameta/nvim-metals', {'branch': 'next'}
+Plug 'scalameta/nvim-metals'
 
 " visual git plugin
 Plug 'airblade/vim-gitgutter'


### PR DESCRIPTION
Hello! I just removed the next branch from nvim-metals as I'll only be sticking to `main` and instead ensure that stays compatible. I did a quick search and only found a couple repos using `next` anyways so figured I'd give you a heads up.